### PR TITLE
release: merge develop into main for updated Java version in GitHub Actions

### DIFF
--- a/.github/workflows/main_pawfectcare.yml
+++ b/.github/workflows/main_pawfectcare.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Java version
         uses: actions/setup-java@v4
         with:
-          java-version: 'java21'
+          java-version: '21'
           distribution: 'microsoft'
 
       - name: Build with Maven


### PR DESCRIPTION
Se actualiza la versión de Java en el archivo de GitHub Actions en la rama main, pasando de java21 a '21', lo cual asegura compatibilidad y estabilidad en el entorno de CI/CD.