### PR TITLE
release: merge develop into main with updated workflow to skip tests

### DIFF
--- a/.github/workflows/main_pawfectcare.yml
+++ b/.github/workflows/main_pawfectcare.yml
@@ -23,7 +23,7 @@ jobs:
           distribution: 'microsoft'
 
       - name: Build with Maven
-        run: mvn clean install
+        run: mvn clean install -DskipTests
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Se actualiza el archivo main_pawfectcare.yml en la rama main para omitir la ejecución de tests en el workflow de GitHub Actions, agilizando el proceso de CI/CD en producción.
